### PR TITLE
Update line 18 to match default path in MDA VST3

### DIFF
--- a/mda_jx10_vst3/config_play_vst3.json
+++ b/mda_jx10_vst3/config_play_vst3.json
@@ -15,7 +15,7 @@
             ],
             "plugins" : [
                 {
-                    "path" : "/usr/lib/VST3/mda-vst3.vst3",
+                    "path" : "/usr/lib/VST3/mda.vst3",
                     "name" : "synth",
                     "type"   : "vst3x",
                     "uid" : "mda JX10"


### PR DESCRIPTION
When unpacking the default `elk-examples` the unpacked instrument library is specified as `/usr/lib/VST3/mjda-vst3.vst3`.    Adjusted the `config.json` to match.